### PR TITLE
fix(cleanTypstSource): add metadata.toml to special files

### DIFF
--- a/lib/cleanTypstSource.nix
+++ b/lib/cleanTypstSource.nix
@@ -5,6 +5,7 @@ lib.cleanSourceWith {
     isTypstSource = lib.hasSuffix ".typ" path;
     isSpecialFile = builtins.elem (builtins.baseNameOf path) [
       "typst.toml"
+      "metadata.toml"
     ];
   in
     type == "directory" || isTypstSource || isSpecialFile;


### PR DESCRIPTION
Add metadata.toml (is used by some templates like [brilliant-cv](https://typst.app/universe/package/brilliant-cv)) to special files