### PR TITLE
chore(envrc): Delete watch_file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,1 @@
-watch_file flake.nix flake.lock
-
 use flake . --impure


### PR DESCRIPTION
`.envrc` file has a `watch_file` syntax, but the `flake.lock` and `flake.nix` file is already tracked files.

### References
https://github.com/nix-community/nix-direnv/blob/7789681eb28fae8de052866f14d009f2375f9362/README.md?plain=1#L276