### PR TITLE
Support for typstPackages from upstream nixpkgs

### DIFF
--- a/examples/typst-packages-nixpkgs/flake.nix
+++ b/examples/typst-packages-nixpkgs/flake.nix
@@ -1,0 +1,103 @@
+{
+  description = "A Typst project that uses Typst packages";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    typix = {
+      url = "github:loqusion/typix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    # Example of downloading icons from a non-flake source
+    # font-awesome = {
+    #   url = "github:FortAwesome/Font-Awesome";
+    #   flake = false;
+    # };
+  };
+
+  outputs = inputs @ {
+    nixpkgs,
+    typix,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      inherit (pkgs) lib;
+
+      typixLib = typix.lib.${system};
+
+      src = typixLib.cleanTypstSource ./.;
+      commonArgs = {
+        typstSource = "main.typ";
+
+        fontPaths = [
+          # Add paths to fonts here
+          # "${pkgs.roboto}/share/fonts/truetype"
+        ];
+
+        virtualPaths = [
+          # Add paths that must be locally accessible to typst here
+          # {
+          #   dest = "icons";
+          #   src = "${inputs.font-awesome}/svgs/regular";
+          # }
+        ];
+      };
+
+      unstable_typstPackages = [
+      ];
+
+      nixpkgs_typstPackages = with pkgs.typstPackages; [
+        cetz_0_3_4
+      ];
+
+      # Compile a Typst project, *without* copying the result
+      # to the current directory
+      build-drv = typixLib.buildTypstProject (commonArgs
+        // {
+          inherit src unstable_typstPackages nixpkgs_typstPackages;
+        });
+
+      # Compile a Typst project, and then copy the result
+      # to the current directory
+      build-script = typixLib.buildTypstProjectLocal (commonArgs
+        // {
+          inherit src unstable_typstPackages nixpkgs_typstPackages;
+        });
+
+      # Watch a project and recompile on changes
+      watch-script = typixLib.watchTypstProject commonArgs;
+    in {
+      checks = {
+        inherit build-drv build-script watch-script;
+      };
+
+      packages.default = build-drv;
+
+      apps = rec {
+        default = watch;
+        build = flake-utils.lib.mkApp {
+          drv = build-script;
+        };
+        watch = flake-utils.lib.mkApp {
+          drv = watch-script;
+        };
+      };
+
+      devShells.default = typixLib.devShell {
+        inherit (commonArgs) fontPaths virtualPaths;
+        packages = [
+          # WARNING: Don't run `typst-build` directly, instead use `nix run .#build`
+          # See https://github.com/loqusion/typix/issues/2
+          # build-script
+          watch-script
+          # More packages can be added here, like typstfmt
+          # pkgs.typstfmt
+        ];
+      };
+    });
+}

--- a/examples/typst-packages-nixpkgs/main.typ
+++ b/examples/typst-packages-nixpkgs/main.typ
@@ -1,0 +1,8 @@
+#import "@preview/cetz:0.3.4"
+
+#cetz.canvas({
+  import cetz.draw: *
+
+  circle((0, 0))
+  line((0, 0), (2, 1))
+})


### PR DESCRIPTION
Upstream `nixpkgs` currently maintains all Typst packages from Typst Universe registry, including their hashes and dependencies. This PR adds support for reusing existing Typst packages from `nixpkgs`. For these packages, users are no longer required to specify their hash and dependencies.

An example is also provided with this PR. Feel free to discard it or merge it into an existing example.