### PR TITLE
fix(cleanTypstSource): include .bib files

### DIFF
--- a/checks/clean-expected/lib.typ
+++ b/checks/clean-expected/lib.typ
@@ -1,0 +1,1 @@
+#bibliography("works.bib")

--- a/checks/clean-expected/works.bib
+++ b/checks/clean-expected/works.bib
@@ -1,0 +1,8 @@
+\begin{thebibliography}{9}
+\bibitem{texbook}
+Donald E. Knuth (1986) \emph{The \TeX{} Book}, Addison-Wesley Professional.
+
+\bibitem{lamport94}
+Leslie Lamport (1994) \emph{\LaTeX: a document preparation system}, Addison
+Wesley, Massachusetts, 2nd ed.
+\end{thebibliography}

--- a/checks/clean/lib.typ
+++ b/checks/clean/lib.typ
@@ -1,0 +1,1 @@
+#bibliography("works.bib")

--- a/checks/clean/works.bib
+++ b/checks/clean/works.bib
@@ -1,0 +1,8 @@
+\begin{thebibliography}{9}
+\bibitem{texbook}
+Donald E. Knuth (1986) \emph{The \TeX{} Book}, Addison-Wesley Professional.
+
+\bibitem{lamport94}
+Leslie Lamport (1994) \emph{\LaTeX: a document preparation system}, Addison
+Wesley, Massachusetts, 2nd ed.
+\end{thebibliography}

--- a/lib/cleanTypstSource.nix
+++ b/lib/cleanTypstSource.nix
@@ -2,11 +2,18 @@
 lib.cleanSourceWith {
   src = lib.cleanSource src;
   filter = path: type: let
-    isTypstSource = lib.hasSuffix ".typ" path;
+    hasAcceptedSuffix = builtins.any (lib.flip lib.hasSuffix path) [
+      ".typ" # Typst files
+      ".bib" # BibLaTeX files
+    ];
     isSpecialFile = builtins.elem (builtins.baseNameOf path) [
       "typst.toml"
       "metadata.toml"
     ];
   in
-    type == "directory" || isTypstSource || isSpecialFile;
+    builtins.any lib.id [
+      (type == "directory")
+      hasAcceptedSuffix
+      isSpecialFile
+    ];
 }


### PR DESCRIPTION
Fixes #67.

See also https://typst.app/docs/reference/model/bibliography/.