### PR TITLE
fix(cleanTypstSource): include .yaml/.yml files

### DIFF
--- a/lib/cleanTypstSource.nix
+++ b/lib/cleanTypstSource.nix
@@ -5,6 +5,8 @@ lib.cleanSourceWith {
     hasAcceptedSuffix = builtins.any (lib.flip lib.hasSuffix path) [
       ".typ" # Typst files
       ".bib" # BibLaTeX files
+      ".yaml" # Hayagriva files
+      ".yml" # Hayagriva files
     ];
     isSpecialFile = builtins.elem (builtins.baseNameOf path) [
       "typst.toml"


### PR DESCRIPTION
https://typst.app/docs/reference/model/bibliography/
<img width="742" height="59" alt="image" src="https://github.com/user-attachments/assets/9abe0527-8d78-4a61-ae30-27f061ea4d44" />
